### PR TITLE
correct submodule download

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Include submodule files
+        run: |
+          # Remove the submodule's .git folder so it becomes a normal directory
+          rm -rf repositories/ultimate_sd_upscale/.git
+          # Add the now "regular" folder to the index
+          git add repositories/ultimate_sd_upscale
+
       - name: Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:

--- a/__init__.py
+++ b/__init__.py
@@ -1,31 +1,31 @@
 import sys
 import os
+
 # Check for original USDU script
 current_dir = os.path.dirname(os.path.realpath(__file__))
 repos_dir = os.path.join(current_dir, "repositories")
 usdu_dir = os.path.join(repos_dir, "ultimate_sd_upscale")
-if len(os.listdir(usdu_dir)) == 0:
+if not len(os.listdir(usdu_dir)):
     print("[USDU] Original USDU script not found, downloading it from https://github.com/Coyote-A/ultimate-upscale-for-automatic1111")
     import urllib.request
     import zipfile
     import shutil
 
-    # Download the repo
-    url = "https://github.com/Coyote-A/ultimate-upscale-for-automatic1111/archive/refs/heads/master.zip"
-    zip_path = os.path.join(repos_dir, "usdu.zip")
+    url = "https://github.com/Coyote-A/ultimate-upscale-for-automatic1111/archive/master.zip"
+    zip_path = os.path.join(current_dir, "usdu_temp.zip")
+
     urllib.request.urlretrieve(url, zip_path)
 
-    # Extract the repo
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
-        zip_ref.extractall(repos_dir)
-    
-    # Move the repo to the correct location
-    extracted_dir = os.path.join(repos_dir, "ultimate-upscale-for-automatic1111-master")
-    shutil.move(extracted_dir, usdu_dir)
+        top_folder = zip_ref.namelist()[0].split('/')[0] + '/'
+        for member in zip_ref.namelist():
+            if member.startswith(top_folder) and not member.endswith('/'):
+                target_path = os.path.join(usdu_dir, member[len(top_folder):])
+                os.makedirs(os.path.dirname(target := os.path.join(usdu_dir, member[len(top_folder):])), exist_ok=True)
+                with zip_ref.open(member) as source, open(target, 'wb') as target_file:
+                    shutil.copyfileobj(fsrc=zip_ref.open(member), fdst=target_file)
 
-    # Clean up
     os.remove(zip_path)
-    
     print("[USDU] Original USDU script downloaded successfully")
 
 # Remove other custom_node paths from sys.path to avoid conflicts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui_ultimatesdupscale"
 description = "ComfyUI nodes for the Ultimate Stable Diffusion Upscale script by Coyote-A."
-version = "1.1.1"
+version = "1.1.2"
 license = { file = "LICENSE" }
 
 [project.urls]


### PR DESCRIPTION
Version `1.1.1` is still broken as it downloads submodule to the `ultimate-upscale-for-automatic1111-master` folder and import fails after that.

This PR corrects that by skipping top directory in archive, plus this PR contains a possible fix with try to adding submodule to git(can not easy test it, so will see after publishing)

Code of downloading submodule manually tested locally.