### PR TITLE
Add Qwen Image Edit support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui_ultimatesdupscale"
 description = "ComfyUI nodes for the Ultimate Stable Diffusion Upscale script by Coyote-A."
-version = "1.3.3"
+version = "1.4.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/utils.py
+++ b/utils.py
@@ -468,6 +468,10 @@ def crop_reference_latents(cond_dict, region, init_size, canvas_size, tile_size,
 
     new_latents = []
     for t in latents:  # (B,C,H_lat_in,W_lat_in)
+        has_5d = False
+        if t.ndim == 5: # (B,C,1,H_lat_in,W_lat_in)
+            has_5d = True
+            t = t.squeeze(2)
         if t.ndim != 4:
             raise ValueError(f"expected BCHW, got {t.shape}")
 
@@ -491,7 +495,8 @@ def crop_reference_latents(cond_dict, region, init_size, canvas_size, tile_size,
                                 size=(H_tile_lat, W_tile_lat),
                                 mode="bilinear",
                                 align_corners=False)
-
+        if has_5d:
+            cropped = cropped.unsqueeze(2)
         new_latents.append(cropped)
 
     cond_dict["reference_latents"] = new_latents


### PR DESCRIPTION
The code in `crop_reference_latents` now checks if a tensor has 5 dimensions, it squeezes it out to convert from `[B, C, 1, H, W]` to `[B, C, H, W]` format before processing, then unsqueeze to `[B, C, 1, H, W]` afterwards.

It now works with models like Qwen Image Edit (including the 2509 variant).