### PR TITLE
feat: support zimage controlnet and qwen diffsynth

### DIFF
--- a/crop_model_patch.py
+++ b/crop_model_patch.py
@@ -23,8 +23,10 @@ def crop_model_cond(
     patched = set()
     for module, module_patches in patches.items():
         for patch in module_patches:
+            print(f"Processing patch {type(patch).__name__} in module {module} with id {id(patch)}")
             if id(patch) in patched:
                 # Avoid cropping the same patch multiple times if it appears in multiple modules
+                print(f"Skipping patch with id {id(patch)} as it has already been processed")
                 continue
             if type(patch).__name__ in ("DiffSynthCnetPatch", "ZImageControlPatch"):
                 crop_control_patch(patch, crop_regions, canvas_size, latent_crop)

--- a/crop_model_patch.py
+++ b/crop_model_patch.py
@@ -16,115 +16,148 @@ def crop_model_cond(
             # Use patched_model here
             ...
     """
+    # Clone is probably not useful, since we have to manage patch state changes anyway due
+    # to ComfyUI commit fe053ba
     patched_model = model.clone()
     patches = patched_model.model_options.get("transformer_options", {}).get(
         "patches", {}
     )
-    patched = set()
+    applied_croppers = {}
     for module, module_patches in patches.items():
         for patch in module_patches:
-            print(f"Processing patch {type(patch).__name__} in module {module} with id {id(patch)}")
-            if id(patch) in patched:
+            print(
+                f"Processing patch {type(patch).__name__} in module {module} with id {id(patch)}"
+            )
+            if id(patch) in applied_croppers:
                 # Avoid cropping the same patch multiple times if it appears in multiple modules
-                print(f"Skipping patch with id {id(patch)} as it has already been processed")
+                print(
+                    f"Skipping patch with id {id(patch)} as it has already been processed"
+                )
                 continue
             if type(patch).__name__ in ("DiffSynthCnetPatch", "ZImageControlPatch"):
-                crop_control_patch(patch, crop_regions, canvas_size, latent_crop)
-            patched.add(id(patch))
+                cropper = ModelPatchCropper(patch).crop(
+                    crop_regions, canvas_size, latent_crop
+                )
+            applied_croppers[id(patch)] = cropper
     try:
         yield patched_model
     finally:
         # Restore original model
-        # Not needed for now; model_options is a deepcopy when model is cloned.
-        pass
+        for patch_id, cropper in applied_croppers.items():
+            print(f"Restoring patch with id {patch_id}")
+            del cropper
 
 
-def crop_control_patch(patch, crop_regions, canvas_size, latent_crop=True):
+class ModelPatchCropper:
     """
-    Crop controlnet patch images and latents.
-
-    Args:
-        patch: The controlnet patch (ZImageControlPatch or DiffSynthCnetPatch)
-        crop_regions: List of (x1, y1, x2, y2) crop coordinates for each tile in the batch
-        canvas_size: (width, height) of the canvas
-        latent_crop: If True, crop the encoded latent directly without re-encoding.
-                     If False, crop pixel image and re-encode via VAE.
+    Handles cropping of model patches that contains controlnet hints.
+    Carries state for the original patch so that it can be restored after cropping.
     """
-    patch_class = type(patch).__name__
-    required_attrs = (
-        "image",
-        "model_patch",
-        "vae",
-        "strength",
-        "encoded_image",
-        "encoded_image_size",
-    )
-    missing_attrs = [attr for attr in required_attrs if not hasattr(patch, attr)]
-    assert not missing_attrs, (
-        f"{patch_class} is missing required attributes: {', '.join(missing_attrs)}"
-    )
 
-    # Normalize to list of regions
-    if not isinstance(crop_regions, list):
-        crop_regions = [crop_regions]
-
-    # Crop the pixel space image
-    assert len(patch.image.shape) == 4, (
-        f"Expected image to have 4 dimensions (b, h, w, c), got {patch.image.shape}"
-    )
-
-    # Calculate crop region relative to image size (image is [b, h, w, c])
-    image_size = (patch.image.shape[2], patch.image.shape[1])  # (w, h)
-
-    # Crop and collect for each region
-    cropped_images = []
-    for crop_region in crop_regions:
-        resized_crop = resize_region(crop_region, canvas_size, image_size)
-        x1, y1, x2, y2 = resized_crop
-        cropped_image = patch.image[:, y1:y2, x1:x2, :]
-        cropped_images.append(cropped_image)
-
-    # Concatenate all cropped images along the batch dimension
-
-    concatenated_image = torch.cat(cropped_images, dim=0)
-    print(
-        f"Cropped {patch_class} image from {patch.image.shape} to {concatenated_image.shape}"
-    )
-    patch.image = concatenated_image
-    patch.encoded_image_size = (
-        concatenated_image.shape[1],
-        concatenated_image.shape[2],
-    )
-
-    if latent_crop:
-        # Crop the encoded latent directly without re-encoding
-        downscale_ratio = patch.vae.spacial_compression_encode()
-        # encoded_image is [b, c, h, w] and encoded_image_size is (h, w) in pixel space
-        assert len(patch.encoded_image.shape) == 4, (
-            f"Expected encoded_image to have 4 dimensions (b, c, h, w), got {patch.encoded_image.shape}"
+    def __init__(self, patch):
+        self.patch = patch
+        self.original_state = {
+            "image": patch.image.clone(),
+            "encoded_image": patch.encoded_image.clone(),
+            "encoded_image_size": patch.encoded_image_size,
+        }
+        self.patch_class = type(patch).__name__
+        required_attrs = (
+            "image",
+            "model_patch",
+            "vae",
+            "strength",
+            "encoded_image",
+            "encoded_image_size",
+        )
+        missing_attrs = [attr for attr in required_attrs if not hasattr(patch, attr)]
+        assert not missing_attrs, (
+            f"{self.patch_class} is missing required attributes: {', '.join(missing_attrs)}"
         )
 
-        # Crop and collect latents for each region
-        cropped_latents = []
+    def __del__(self):
+        # Ensure original state is restored when the object is deleted
+        self.patch.image = self.original_state["image"]
+        self.patch.encoded_image = self.original_state["encoded_image"]
+        self.patch.encoded_image_size = self.original_state["encoded_image_size"]
+
+    def crop(self, crop_regions, canvas_size, latent_crop=True):
+        """
+        Crop controlnet patch images and latents.
+
+        Args:
+            patch: The controlnet patch (ZImageControlPatch or DiffSynthCnetPatch)
+            crop_regions: List of (x1, y1, x2, y2) crop coordinates for each tile in the batch
+            canvas_size: (width, height) of the canvas
+            latent_crop: If True, crop the encoded latent directly without re-encoding.
+                        If False, crop pixel image and re-encode via VAE.
+        """
+        patch = self.patch
+        patch_class = self.patch_class
+
+        # Normalize to list of regions
+        if not isinstance(crop_regions, list):
+            crop_regions = [crop_regions]
+
+        # Crop the pixel space image
+        assert len(patch.image.shape) == 4, (
+            f"Expected image to have 4 dimensions (b, h, w, c), got {patch.image.shape}"
+        )
+
+        # Calculate crop region relative to image size (image is [b, h, w, c])
+        image_size = (patch.image.shape[2], patch.image.shape[1])  # (w, h)
+
+        # Crop and collect for each region
+        cropped_images = []
         for crop_region in crop_regions:
             resized_crop = resize_region(crop_region, canvas_size, image_size)
-            # Convert pixel crop to latent space crop
-            x1, y1, x2, y2 = tuple(x // downscale_ratio for x in resized_crop)
-            cropped_latent = patch.encoded_image[:, :, y1:y2, x1:x2]
-            cropped_latents.append(cropped_latent)
+            x1, y1, x2, y2 = resized_crop
+            cropped_image = patch.image[:, y1:y2, x1:x2, :]
+            cropped_images.append(cropped_image)
 
-        # Concatenate all cropped latents along the batch dimension
-        # and update the patch with cropped latent
-        patch.encoded_image = torch.cat(cropped_latents, dim=0)
-    else:
-        # Re-encode the cropped image by calling __init__
-        # This will encode the cropped_image and update encoded_image/encoded_image_size
-        # ZImageControlPatch supports inpaint_image, may have to account for that in the future
-        patch.__init__(
-            patch.model_patch,
-            patch.vae,
-            concatenated_image,
-            patch.strength,
-            # inpaint_image=patch.inpaint_image,
-            mask=patch.mask,
+        # Concatenate all cropped images along the batch dimension
+
+        concatenated_image = torch.cat(cropped_images, dim=0)
+        print(
+            f"Cropped {patch_class} image from {patch.image.shape} to {concatenated_image.shape}"
         )
+        patch.image = concatenated_image
+        patch.encoded_image_size = (
+            concatenated_image.shape[1],
+            concatenated_image.shape[2],
+        )
+
+        if latent_crop:
+            # Crop the encoded latent directly without re-encoding
+            downscale_ratio = patch.vae.spacial_compression_encode()
+            # encoded_image is [b, c, h, w] and encoded_image_size is (h, w) in pixel space
+            assert len(patch.encoded_image.shape) == 4, (
+                f"Expected encoded_image to have 4 dimensions (b, c, h, w), got {patch.encoded_image.shape}"
+            )
+
+            # Crop and collect latents for each region
+            cropped_latents = []
+            for crop_region in crop_regions:
+                resized_crop = resize_region(crop_region, canvas_size, image_size)
+                # Convert pixel crop to latent space crop
+                x1, y1, x2, y2 = tuple(x // downscale_ratio for x in resized_crop)
+                cropped_latent = patch.encoded_image[:, :, y1:y2, x1:x2]
+                cropped_latents.append(cropped_latent)
+
+            # Concatenate all cropped latents along the batch dimension
+            # and update the patch with cropped latent
+            patch.encoded_image = torch.cat(cropped_latents, dim=0)
+        else:
+            # Re-encode the cropped image by calling __init__
+            # This will encode the cropped_image and update encoded_image/encoded_image_size
+            # ZImageControlPatch supports inpaint_image, may have to account for that in the future
+            patch.__init__(
+                patch.model_patch,
+                patch.vae,
+                concatenated_image,
+                patch.strength,
+                inpaint_image=patch.inpaint_image,
+                mask=patch.mask,
+            )
+
+        return self

--- a/crop_model_patch.py
+++ b/crop_model_patch.py
@@ -1,7 +1,11 @@
 from contextlib import contextmanager
+import logging
 import torch
 
 from usdu_utils import resize_region
+
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -25,12 +29,12 @@ def crop_model_cond(
     applied_croppers = {}
     for module, module_patches in patches.items():
         for patch in module_patches:
-            print(
+            logger.debug(
                 f"Processing patch {type(patch).__name__} in module {module} with id {id(patch)}"
             )
             if id(patch) in applied_croppers:
                 # Avoid cropping the same patch multiple times if it appears in multiple modules
-                print(
+                logger.debug(
                     f"Skipping patch with id {id(patch)} as it has already been processed"
                 )
                 continue
@@ -44,7 +48,7 @@ def crop_model_cond(
     finally:
         # Restore original model
         for patch_id, cropper in applied_croppers.items():
-            print(f"Restoring patch with id {patch_id}")
+            logger.debug(f"Restoring patch with id {patch_id}")
             del cropper
 
 
@@ -118,7 +122,7 @@ class ModelPatchCropper:
         # Concatenate all cropped images along the batch dimension
 
         concatenated_image = torch.cat(cropped_images, dim=0)
-        print(
+        logger.debug(
             f"Cropped {patch_class} image from {patch.image.shape} to {concatenated_image.shape}"
         )
         patch.image = concatenated_image

--- a/crop_model_patch.py
+++ b/crop_model_patch.py
@@ -1,0 +1,128 @@
+from contextlib import contextmanager
+import torch
+
+from usdu_utils import resize_region
+
+
+@contextmanager
+def crop_model_cond(
+    model, crop_regions, init_size, canvas_size, tile_size, latent_crop=False
+):
+    """
+    Context manager to crop model patches that may contain controlnet hints.
+
+    Usage:
+        with crop_model_cond(model, ...) as patched_model:
+            # Use patched_model here
+            ...
+    """
+    patched_model = model.clone()
+    patches = patched_model.model_options.get("transformer_options", {}).get(
+        "patches", {}
+    )
+    patched = set()
+    for module, module_patches in patches.items():
+        for patch in module_patches:
+            if id(patch) in patched:
+                # Avoid cropping the same patch multiple times if it appears in multiple modules
+                continue
+            if type(patch).__name__ in ("DiffSynthCnetPatch", "ZImageControlPatch"):
+                crop_control_patch(patch, crop_regions, canvas_size, latent_crop)
+            patched.add(id(patch))
+    try:
+        yield patched_model
+    finally:
+        # Restore original model
+        # Not needed for now; model_options is a deepcopy when model is cloned.
+        pass
+
+
+def crop_control_patch(patch, crop_regions, canvas_size, latent_crop=True):
+    """
+    Crop controlnet patch images and latents.
+
+    Args:
+        patch: The controlnet patch (ZImageControlPatch or DiffSynthCnetPatch)
+        crop_regions: List of (x1, y1, x2, y2) crop coordinates for each tile in the batch
+        canvas_size: (width, height) of the canvas
+        latent_crop: If True, crop the encoded latent directly without re-encoding.
+                     If False, crop pixel image and re-encode via VAE.
+    """
+    patch_class = type(patch).__name__
+    required_attrs = (
+        "image",
+        "model_patch",
+        "vae",
+        "strength",
+        "encoded_image",
+        "encoded_image_size",
+    )
+    missing_attrs = [attr for attr in required_attrs if not hasattr(patch, attr)]
+    assert not missing_attrs, (
+        f"{patch_class} is missing required attributes: {', '.join(missing_attrs)}"
+    )
+
+    # Normalize to list of regions
+    if not isinstance(crop_regions, list):
+        crop_regions = [crop_regions]
+
+    # Crop the pixel space image
+    assert len(patch.image.shape) == 4, (
+        f"Expected image to have 4 dimensions (b, h, w, c), got {patch.image.shape}"
+    )
+
+    # Calculate crop region relative to image size (image is [b, h, w, c])
+    image_size = (patch.image.shape[2], patch.image.shape[1])  # (w, h)
+
+    # Crop and collect for each region
+    cropped_images = []
+    for crop_region in crop_regions:
+        resized_crop = resize_region(crop_region, canvas_size, image_size)
+        x1, y1, x2, y2 = resized_crop
+        cropped_image = patch.image[:, y1:y2, x1:x2, :]
+        cropped_images.append(cropped_image)
+
+    # Concatenate all cropped images along the batch dimension
+
+    concatenated_image = torch.cat(cropped_images, dim=0)
+    print(
+        f"Cropped {patch_class} image from {patch.image.shape} to {concatenated_image.shape}"
+    )
+    patch.image = concatenated_image
+    patch.encoded_image_size = (
+        concatenated_image.shape[1],
+        concatenated_image.shape[2],
+    )
+
+    if latent_crop:
+        # Crop the encoded latent directly without re-encoding
+        downscale_ratio = patch.vae.spacial_compression_encode()
+        # encoded_image is [b, c, h, w] and encoded_image_size is (h, w) in pixel space
+        assert len(patch.encoded_image.shape) == 4, (
+            f"Expected encoded_image to have 4 dimensions (b, c, h, w), got {patch.encoded_image.shape}"
+        )
+
+        # Crop and collect latents for each region
+        cropped_latents = []
+        for crop_region in crop_regions:
+            resized_crop = resize_region(crop_region, canvas_size, image_size)
+            # Convert pixel crop to latent space crop
+            x1, y1, x2, y2 = tuple(x // downscale_ratio for x in resized_crop)
+            cropped_latent = patch.encoded_image[:, :, y1:y2, x1:x2]
+            cropped_latents.append(cropped_latent)
+
+        # Concatenate all cropped latents along the batch dimension
+        # and update the patch with cropped latent
+        patch.encoded_image = torch.cat(cropped_latents, dim=0)
+    else:
+        # Re-encode the cropped image by calling __init__
+        # This will encode the cropped_image and update encoded_image/encoded_image_size
+        # ZImageControlPatch supports inpaint_image, may have to account for that in the future
+        patch.__init__(
+            patch.model_patch,
+            patch.vae,
+            concatenated_image,
+            patch.strength,
+            # inpaint_image=patch.inpaint_image,
+            mask=patch.mask,
+        )

--- a/test/test_controlnet.py
+++ b/test/test_controlnet.py
@@ -194,7 +194,8 @@ class TestZImageFunControlNet:
         # Verify reference image match
         logger = logging.getLogger(TestZImageFunControlNet.__name__)
         test_img_dir = test_dirs.test_images
-        filename = CATEGORY / (f"controlnet_zimage_fun_{i + 1}_batch{batch_size}" + EXT)
+        batch_str = f"_batch{batch_size}" if batch_size > 1 else ""
+        filename = CATEGORY / (f"controlnet_zimage_fun_{i + 1}{batch_str}" + EXT)
         sample_dir = test_dirs.sample_images
         save_image(upscaled, sample_dir / filename)
         upscaled = load_image(sample_dir / filename)

--- a/test/test_controlnet.py
+++ b/test/test_controlnet.py
@@ -88,3 +88,127 @@ class TestControlNet:
         diff = img_tensor_mae(blur(upscaled), blur(test_img))
         logger.info(f"ControlNet Upscaled Image Diff: {diff}")
         assert diff < 0.01, "ControlNet upscaled image does not match its test image."
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+class TestZImageFunControlNet:
+    """Integration tests for the upscaling workflow with Z-Image's Fun Controlnet."""
+
+    @pytest.fixture(scope="function")
+    def upscaled(
+        self,
+        base_image,
+        node_classes,
+        seed,
+        batch_size,
+        test_dirs: DirectoryConfig,
+    ):
+        # TODO: Fixtures for z-image if more tests are needed for this model
+        with torch.inference_mode():
+            image, _, _ = base_image
+            # (image,) = execute(
+            #     node_classes["ImageScale"],
+            #     image=image,
+            #     upscale_method="lanczos",
+            #     width=512,
+            #     height=512,
+            #     crop="center",
+            # )
+            (model,) = execute(
+                node_classes["UNETLoader"],
+                "z-image-turbo_fp8_scaled_e4m3fn_KJ.safetensors",
+                weight_dtype="fp8_e4m3fn",
+            )
+            (clip,) = execute(
+                node_classes["CLIPLoader"], "qwen_3_4b.safetensors", type="lumina2"
+            )
+            (vae,) = execute(node_classes["VAELoader"], "ae.safetensors")
+            prompt = "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,"
+            (pos,) = execute(node_classes["CLIPTextEncode"], clip, prompt)
+            (neg,) = execute(node_classes["ConditioningZeroOut"], pos)
+            depth_hint = load_image(test_dirs.test_images / CATEGORY / "depth2.png")
+            canny_hint = load_image(test_dirs.test_images / CATEGORY / "canny2.png")
+            canny_hint = canny_hint.repeat(1, 1, 1, 3)  # Convert from grayscale to RGB
+            (hint,) = execute(
+                node_classes["ImageBlend"], depth_hint, canny_hint, 1.0, "overlay"
+            )
+            hint = hint[..., :3]  # Blend and drop alpha
+            # Both the image and depth hint are 512x512
+            (hint,) = execute(
+                node_classes["ImageScaleBy"],
+                image=hint,
+                upscale_method="lanczos",
+                scale_by=2.0,
+            )
+            save_image(hint, test_dirs.sample_images / CATEGORY / "blended_hint.png")
+            (image,) = execute(
+                node_classes["ImageScaleBy"],
+                image=image,
+                upscale_method="lanczos",
+                scale_by=2.0,
+            )
+            (model_patch,) = execute(
+                node_classes["ModelPatchLoader"],
+                "Z-Image-Turbo-Fun-Controlnet-Tile-2.1-2601-8steps.safetensors",
+            )
+            (model,) = execute(
+                node_classes["ZImageFunControlnet"],
+                model,
+                model_patch,
+                vae,
+                hint,
+                strength=1.0,
+            )
+
+            usdu = node_classes["UltimateSDUpscaleNoUpscale"]
+            (upscaled,) = usdu().upscale(
+                upscaled_image=image,
+                model=model,
+                positive=pos,
+                negative=neg,
+                vae=vae,
+                seed=seed,
+                steps=5,
+                cfg=1,
+                sampler_name="euler",
+                scheduler="normal",
+                denoise=0.8,
+                mode_type="Chess",
+                tile_width=512,
+                tile_height=512,
+                mask_blur=16,
+                tile_padding=128,
+                seam_fix_mode="None",
+                seam_fix_denoise=1.0,
+                seam_fix_width=64,
+                seam_fix_mask_blur=8,
+                seam_fix_padding=16,
+                force_uniform_tiles=True,
+                tiled_decode=False,
+                batch_size=batch_size,
+            )
+
+        return upscaled
+
+    def _verify_match(self, upscaled, i, batch_size, test_dirs, threshold):
+        # Verify reference image match
+        logger = logging.getLogger(TestZImageFunControlNet.__name__)
+        test_img_dir = test_dirs.test_images
+        filename = CATEGORY / (f"controlnet_zimage_fun_{i + 1}_batch{batch_size}" + EXT)
+        sample_dir = test_dirs.sample_images
+        save_image(upscaled, sample_dir / filename)
+        upscaled = load_image(sample_dir / filename)
+        test_img = load_image(test_img_dir / filename)
+
+        # Reduce high-frequency noise differences with gaussian blur
+        diff = img_tensor_mae(blur(upscaled), blur(test_img))
+        logger.info(f"Diff: {diff}")
+        assert diff < threshold, (
+            f"{filename} does not match its test image. Diff: {diff}"
+        )
+
+    def test_image1(self, upscaled, batch_size, test_dirs):
+        self._verify_match(upscaled[0], 0, batch_size, test_dirs, threshold=0.01)
+
+    def test_image2(self, upscaled, batch_size, test_dirs):
+        self._verify_match(upscaled[1], 1, batch_size, test_dirs, threshold=0.01)

--- a/usdu_patch.py
+++ b/usdu_patch.py
@@ -20,6 +20,7 @@ import torch
 from tqdm import tqdm
 
 from comfy_extras.nodes_custom_sampler import SamplerCustom
+from crop_model_patch import crop_model_cond
 from nodes import common_ksampler, VAEEncode, VAEDecode, VAEDecodeTiled
 
 import modules.shared as shared
@@ -285,10 +286,11 @@ def _process_batch_tiles(p,
     positive_cropped = usdu_utils.crop_cond(p.positive, batch_crop_regions, p.init_size, images[0].size, first_tile_size)
     negative_cropped = usdu_utils.crop_cond(p.negative, batch_crop_regions, p.init_size, images[0].size, first_tile_size)
 
-    # Sampling
-    samples = _sample(p.model, p.seed, p.steps, p.cfg, p.sampler_name, p.scheduler,
-                      positive_cropped, negative_cropped, latent, p.denoise,
-                      p.custom_sampler, p.custom_sigmas)
+    with crop_model_cond(p.model, batch_crop_regions, p.init_size, images[0].size, first_tile_size) as model:
+        # Sampling
+        samples = _sample(model, p.seed, p.steps, p.cfg, p.sampler_name, p.scheduler,
+                        positive_cropped, negative_cropped, latent, p.denoise,
+                        p.custom_sampler, p.custom_sigmas)
 
     # Update progress bar
     if p.progress_bar_enabled:


### PR DESCRIPTION
Crop controlnet hints within model patch nodes for zimage controlnet and qwen diffsynth in the same way as controlnet applied via conditioning nodes.
Tests for zimage; no tests for qwen for now.